### PR TITLE
Update conda before enabling conda-forge in Appveyor CI

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -20,7 +20,8 @@ environment:
 
 install:
   - call %CONDA_INSTALL_LOCN%\Scripts\activate.bat
-  - conda config --set auto_update_conda false
+#  - conda config --set auto_update_conda false
+  - conda update --yes -n base conda
   - conda config --add channels conda-forge --force
   - conda install --yes --quiet flang jom
   - call "C:\Program Files (x86)\Microsoft Visual Studio 14.0\VC\vcvarsall.bat" amd64


### PR DESCRIPTION
**Description**
fixes recent CI failure  "InvalidVersionSpecError: Invalid version spec =2.7" (see also conda/conda issue 10618)
**Checklist**
N/A
